### PR TITLE
Set Go version to minimum required 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jonasbn/punycode
 
-go 1.25.7
+go 1.25
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary
Updates the Go version in `go.mod` from `1.25.7` to `1.25` to follow idiomatic Go style.

## Changes
- Changed `go 1.25.7` to `go 1.25` in go.mod

## Rationale
- The two-part version format (`go 1.X`) is the standard Go convention
- The patch version (`.7`) is unnecessary and non-standard
- The minimum required Go version is **1.25** based on dependencies:
  - `golang.org/x/net` v0.53.0 requires Go 1.25.0
  - `golang.org/x/text` v0.36.0 requires Go 1.25.0

This change maintains the same minimum version requirement while following Go community best practices.