### PR TITLE
Use stable Go version in workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: 1.25.7
+        go-version: stable
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: stable
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: stable
+          go-version-file: go.mod
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.7
+          go-version: stable
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1


### PR DESCRIPTION
## Summary

- Replace hardcoded `go-version: 1.25.7` with `go-version: stable` in `go.yml` and `release.yml`
- `codeql.yml` uses `Autobuild` with no explicit Go version — no change needed
- `go.mod` minimum version (`go 1.25.0`) continues to serve as the floor

Using `stable` means CI and release builds automatically pick up new patch (and minor) releases without manual workflow updates, while Go's compatibility guarantee keeps this low-risk.

## Test plan

- [ ] Verify the `Go` CI workflow passes on this PR
- [ ] Confirm `setup-go` resolves `stable` to the expected Go version in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)